### PR TITLE
Only resolve root import paths rather than all

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -98,13 +98,12 @@ exports.resolve = (source, file, config = {}, babelrc = '.babelrc') => {
 
         if (hasRootPathPrefixInString(source, prefix)) {
             transformedSource = transformRelativeToRootPath(source, suffix, prefix);
+            // Since babel-plugin-root-import 5.0.0 relative path is now actually relative to the root.
+            // Node resolver expects that path would be relative to file, so we have to resolve it first
+            transformedSource = path.resolve(transformedSource);
             break;
         }
     }
-
-    // Since babel-plugin-root-import 5.0.0 relative path is now actually relative to the root.
-    // Node resolver expects that path would be relative to file, so we have to resolve it first
-    transformedSource = path.resolve(transformedSource);
 
     return nodeResolve(transformedSource, file, {});
 };

--- a/test/index.js
+++ b/test/index.js
@@ -125,6 +125,66 @@ test('Does nothing when babel plugin not listed in .babelrc', (t) => {
     t.end();
 });
 
+test('Should resolve relative paths in the same directory', (t) => {
+    const oldCwd = process.cwd();
+    const fromFile = relativeToTestDir('lookup/submodule/lib/path.js');
+
+    process.chdir(relativeToTestDir('lookup/submodule/lib/'));
+
+    const actual = resolve('./other.js', fromFile, {});
+    const expected = expectResolvedTo('lookup/submodule/lib/other.js');
+
+    process.chdir(oldCwd);
+
+    t.deepEqual(actual, expected);
+    t.end();
+});
+
+test('Should resolve relative paths in the parent directory', (t) => {
+    const oldCwd = process.cwd();
+    const fromFile = relativeToTestDir('lookup/submodule/lib/path.js');
+
+    process.chdir(relativeToTestDir('lookup/submodule/lib/'));
+
+    const actual = resolve('../package.json', fromFile, {});
+    const expected = expectResolvedTo('lookup/submodule/package.json');
+
+    process.chdir(oldCwd);
+
+    t.deepEqual(actual, expected);
+    t.end();
+});
+
+test('Should resolve external dependencies', (t) => {
+    const oldCwd = process.cwd();
+    const fromFile = relativeToTestDir('lookup/submodule/lib/path.js');
+
+    process.chdir(relativeToTestDir('lookup/submodule/lib/'));
+
+    const actual = resolve('lodash', fromFile, {});
+    const expected = expectResolvedTo('../node_modules/lodash/lodash.js');
+
+    process.chdir(oldCwd);
+
+    t.deepEqual(actual, expected);
+    t.end();
+});
+
+test('Should resolve builtin core modules', (t) => {
+    const oldCwd = process.cwd();
+    const fromFile = relativeToTestDir('lookup/submodule/lib/path.js');
+
+    process.chdir(relativeToTestDir('lookup/submodule/lib/'));
+
+    const actual = resolve('path', fromFile, {});
+    const expected = { found: true, path: null };
+
+    process.chdir(oldCwd);
+
+    t.deepEqual(actual, expected);
+    t.end();
+});
+
 test('Should not resolve file that doesn\'t exists', (t) => {
     const prefix1 = resolve('@/nonexistent', __filename, {});
     const expected1 = expectResolvedTo(false);


### PR DESCRIPTION
The paths from root imports need to be resolved to relative paths from the file, however, currently, the resolver is doing it for _all_ paths. This was causing all imports to fail except for ones which had a root import symbol.