### PR TITLE
Allow sending configs to node-resolver.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-import-resolver-babel-plugin-root-import",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "src/index.js",
   "description": "fork of eslint-import-resolver-babel-root-import that works",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,11 @@
     {
       "name": "Christian Le",
       "url": "http://christianle.com"
+    },
+    {
+      "name": "Héctor Menéndez",
+      "email": "hector@gik.mx",
+      "url": "http://gik.mx"
     }
   ],
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -87,14 +87,17 @@ exports.resolve = (source, file, config = {}, babelrc = '.babelrc') => {
 
     const rootPathConfig = optsArray.map((item = {}) => ({
         rootPathPrefix: isString(item.rootPathPrefix) ? item.rootPathPrefix : '~',
-        rootPathSuffix: isString(item.rootPathSuffix) ? item.rootPathSuffix.replace(/^(\/)|(\/)$/g, '') : ''
+        rootPathSuffix: isString(item.rootPathSuffix) ? item.rootPathSuffix.replace(/^(\/)|(\/)$/g, '') : '',
+        ...item,
     }));
 
     let transformedSource = source;
+    let resolverConfig = {};
     for (let i = 0; i < rootPathConfig.length; i += 1) {
-        const option = rootPathConfig[i];
-        const prefix = option.rootPathPrefix;
-        const suffix = option.rootPathSuffix;
+        // The remaining configs will be sent to node.resolver to deal with special cases.
+        // eg. Adding .jsx to the extension list.
+        const { rootPathPrefix: prefix, rootPathSuffix: suffix, ...option } = rootPathConfig[i];
+        resolverConfig = option;
 
         if (hasRootPathPrefixInString(source, prefix)) {
             transformedSource = transformRelativeToRootPath(source, suffix, prefix);
@@ -104,7 +107,6 @@ exports.resolve = (source, file, config = {}, babelrc = '.babelrc') => {
             break;
         }
     }
-
-    return nodeResolve(transformedSource, file, {});
+    return nodeResolve(transformedSource, file, resolverConfig);
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -117,6 +117,18 @@ test('Skips package.json with no "babel" hash in it', (t) => {
     t.end();
 });
 
+test('Should send extra configuration to node resolver', (t) => {
+    const expected = { found: true, path: relativeToTestDir('modules/component.jsx') };
+    const actual = resolve('@/component', __filename, {
+        extensions: ['.jsx'],
+        rootPathSuffix: 'modules',
+        rootPathPrefix: '@'
+    });
+
+    t.deepEqual(actual, expected);
+    t.end();
+});
+
 test('Does nothing when babel plugin not listed in .babelrc', (t) => {
     const result = resolve('~/modules/file', __filename, {}, '.babelrcNotListed');
     const expected = expectResolvedTo(false);

--- a/test/modules/component.jsx
+++ b/test/modules/component.jsx
@@ -1,0 +1,1 @@
+module.exports = function(){ return null  };


### PR DESCRIPTION
When dealing with "non-standard" extensions like ".jsx" one has to always specify the extension when importing, after reading the node-resolver code I've noticed that this library is always sending an empty object as config, making impossible to configure for such cases. This PR fixes that. I noticed you're not using "newer" JS syntax here, but I checked the compatibility table and everything I'm using has already landed in the LTS version of Node, so I went for the less verbose approach. 

Greets!